### PR TITLE
Changed NSIS syntax description to just "NSIS"

### DIFF
--- a/NSIS.tmLanguage
+++ b/NSIS.tmLanguage
@@ -14,7 +14,7 @@
 	</array>
 
 	<key>name</key>
-	<string>NSIS Installer</string>
+	<string>NSIS</string>
 	<key>patterns</key>
 	<array>
 		<dict>


### PR DESCRIPTION
Seeing the description `NSIS Installer` felt like seeing `ATM machines`… :(
