### PR TITLE
Add support for "!include: error in script:" error types

### DIFF
--- a/NSIS.sublime-build
+++ b/NSIS.sublime-build
@@ -1,7 +1,7 @@
 {
   "cmd": ["makensis", "$file"],
   "working_dir": "${project_path:${folder}}",
-  "file_regex": "Error in script \"(...*?)\" on line ([0-9]*)",
+  "file_regex": ".*rror in script:? \"(...*?)\" on line ([0-9]*)",
   "selector" : "source.nsis",
   
   "windows":


### PR DESCRIPTION
this is a small fix for the build file to allow F4 after a failing build to iterate over all errors, on projects which include other files.
