### PR TITLE
fixed path

### DIFF
--- a/NSIS (Unicode).sublime-build
+++ b/NSIS (Unicode).sublime-build
@@ -6,6 +6,6 @@
   
   "windows":
     {
-      "cmd": ["$packages/NSIS/nsis_build.bat", "u", "$file"]
+      "cmd": ["$packages\\NSIS\\nsis_build.bat", "u", "$file"]
     }
 }

--- a/NSIS.sublime-build
+++ b/NSIS.sublime-build
@@ -6,6 +6,6 @@
   
   "windows":
     {
-      "cmd": ["$packages/NSIS/nsis_build.bat", "a", "$file"]
+      "cmd": ["$packages\\NSIS\\nsis_build.bat", "a", "$file"]
     }
 }


### PR DESCRIPTION
For some reason, I can no longer build scripts on Sublime Text 3 on Windows. However, while looking at the build tool, I noticed the path to the batchfile uses the wrong kind of slashes (though I do recall these _used_ to work back on ST2). Anyway, I changed the slashes (which offered no solution for me)

Also, I wonder whether the Unicode build tool is still required. I think that most people will switch to the official NSIS Unicode build, which allows choosing output encoding within the script. Hence, two commands will no longer be necessary. However, I wanted to check what you guys make of it. Should we wait some more? NSIS development is slow and NSIS 3.0 only reached alpha 2 recently (long way to go, from what I know!)
