### PR TITLE
Fix #32 - Wrong matching group in syntax file

### DIFF
--- a/NSIS.sublime-syntax
+++ b/NSIS.sublime-syntax
@@ -85,4 +85,4 @@ contexts:
           pop: true
     - match: (\!include|\!insertmacro)\b
       captures:
-        match: keyword.control.import.nsis
+        0: keyword.control.import.nsis


### PR DESCRIPTION
Maybe this is strictly checked starting with Sublime 3114. Updating the matching group fixes the loading problem.