### PR TITLE
do not distribute screenshots

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+screenshots/ export-ignore


### PR DESCRIPTION
We don't need those screenshots to be distributed to end users, right? This will greatly reduce the package size.